### PR TITLE
context_test won't compile on Archer2

### DIFF
--- a/xios_examples/context_test/Makefile
+++ b/xios_examples/context_test/Makefile
@@ -7,10 +7,10 @@
 #
 # Environment Variables expected by this MakeFile:
 #
-# NETCDF_LIB_DIR: the directories for the netCDF lib files
+# NETCDF_LIBDIR: the directories for the netCDF lib files
 #                 encoded as a -L string, e.g.
 #                 "-L/dir1 -L/dir2"
-# NETCDF_INC_DIR: the directories for the netCDF include files
+# NETCDF_INCDIR: the directories for the netCDF include files
 #                 encoded as a -I string, e.g.
 #                 "-I/dir3 -I/dir4"
 #     (note, this is for consistency with the XIOS build process

--- a/xios_examples/context_test/Makefile
+++ b/xios_examples/context_test/Makefile
@@ -21,7 +21,7 @@
 # XIOS_LIBDIR: The directory for XIOS lib files
 # XIOS_BINDIR: The directory for XIOS binary files
 
-FCFLAGS = -g -ffree-line-length-none
+FCFLAGS = -g
 
 FC = mpif90 # compiler driver for MPI programs
 
@@ -36,6 +36,8 @@ LDFLAGS = \
         -lnetcdf \
         -lnetcdff \
         -lstdc++
+
+.PHONY: all, clean, run
 
 OBJ = custom_type_mod.o context_def_mod.o
 


### PR DESCRIPTION
fixes #17 

updates to the specific (non-shared) Makefile for the `context_test` example added in #14