### PR TITLE
Manage Environments - simplify Make

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -44,11 +44,13 @@ jobs:
           cd ../..
       - name: run resample example
         run: |
-          . arch/arch-GCC_LINUX_APT.env
-          . arch/arch-GCC_LINUX_APT.path
           export XIOS_BINDIR=$PWD/XIOS/bin
           export XIOS_INCDIR=$PWD/XIOS/inc
           export XIOS_LIBDIR=$PWD/XIOS/lib
+          export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/netcdf/mpi/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+          export LDFLAGS="-L$XIOS_LIBDIR -lxios $(pkg-config --libs netcdf) $(pkg-config --libs netcdf-fortran) -lstdc++"
+          export FCFLAGS="-g -I$XIOS_INCDIR $(pkg-config --cflags-only-I netcdf) $(pkg-config --cflags-only-I netcdf-fortran)"
+          export FC=mpif90
 
           export MVER=${{ matrix.version }}
           export MPI_FLAVOUR='openmpi'

--- a/archerEnv
+++ b/archerEnv
@@ -8,9 +8,6 @@ module load cray-netcdf-hdf5parallel
 module load cray-python
 module load netcdf4
 
-export NETCDF_LIBDIR=-L$NETCDF_DIR/lib
-export NETCDF_INCDIR=-I$NETCDF_DIR/include/
-
 # set XIOS build to XIOS3 marqh build, if not already set
 : ${XIOS_DIR=/work/n02/n02/marqh/metofficegit/tcd-XIOS3-extras}
 
@@ -18,6 +15,13 @@ export NETCDF_INCDIR=-I$NETCDF_DIR/include/
 export XIOS_INCDIR=$XIOS_DIR/inc
 export XIOS_LIBDIR=$XIOS_DIR/lib
 export XIOS_BINDIR=$XIOS_DIR/bin
+
+# ensure netcdf is on the LD path & flags
+export LD_LIBRARY_PATH=$NETCDF_LIBDIR:$LD_LIBRARY_PATH
+export LDFLAGS="-L$XIOS_LIBDIR -lxios -L$NETCDF_DIR/lib -lnetcdf -lnetcdff -lstdc++"
+
+export FCFLAGS="-g -I$XIOS_INCDIR -I$$NETCDF_DIR/include"
+export FC=mpif90
 
 # set env variable for run switching (mpiexec / srun) and iodef patching (transport)
 export PLATFORM=Archer2

--- a/azspiceEnv
+++ b/azspiceEnv
@@ -1,0 +1,21 @@
+# this environment management script needs to be sourced in order to provide
+# equivalent functionality on the MO AZ Spice linux desktop to the Github CI environment.
+# `. azspiceEnv`
+
+# load Azure Spice Spack xios module
+module load xios
+
+# ensure netcdf is on the LD path & flags
+export LD_LIBRARY_PATH=${NETCDFF_ROOT}/lib:$LD_LIBRARY_PATH
+export LDFLAGS="-L$XIOS_LIBDIR -lxios $(pkg-config --libs netcdf) $(pkg-config --libs netcdf-fortran) -lstdc++"
+
+# provide explit path set to the arch script for netCDF linking
+export NETCDF_LIBDIR="-L$NETCDFC_ROOT/lib -L$NETCDFF_ROOT/lib"
+export NETCDF_INCDIR="-L$NETCDFC_ROOT/include -L$NETCDFF_ROOT/include"
+
+# provide specific sub_paths for the demonstration build
+export XIOS_INCDIR=$XIOS_ROOT/include
+export XIOS_LIBDIR=$XIOS_ROOT/lib
+export XIOS_BINDIR=$XIOS_ROOT/bin
+
+export MVER=XIOS/trunk@2252

--- a/azspiceEnv
+++ b/azspiceEnv
@@ -5,17 +5,16 @@
 # load Azure Spice Spack xios module
 module load xios
 
-# ensure netcdf is on the LD path & flags
-export LD_LIBRARY_PATH=${NETCDFF_ROOT}/lib:$LD_LIBRARY_PATH
-export LDFLAGS="-L$XIOS_LIBDIR -lxios $(pkg-config --libs netcdf) $(pkg-config --libs netcdf-fortran) -lstdc++"
-
-# provide explit path set to the arch script for netCDF linking
-export NETCDF_LIBDIR="-L$NETCDFC_ROOT/lib -L$NETCDFF_ROOT/lib"
-export NETCDF_INCDIR="-L$NETCDFC_ROOT/include -L$NETCDFF_ROOT/include"
-
 # provide specific sub_paths for the demonstration build
 export XIOS_INCDIR=$XIOS_ROOT/include
 export XIOS_LIBDIR=$XIOS_ROOT/lib
 export XIOS_BINDIR=$XIOS_ROOT/bin
+
+# ensure netcdf is on the LD path & flags
+export LD_LIBRARY_PATH=${NETCDFF_ROOT}/lib:$LD_LIBRARY_PATH
+export LDFLAGS="-L$XIOS_LIBDIR -lxios $(pkg-config --libs netcdf) $(pkg-config --libs netcdf-fortran) -lstdc++"
+
+export FCFLAGS="-g -I$XIOS_INCDIR $(pkg-config --cflags-only-I netcdf) $(pkg-config --cflags-only-I netcdf-fortran)"
+export FC=mpif90
 
 export MVER=XIOS/trunk@2252

--- a/desktopEnv
+++ b/desktopEnv
@@ -10,16 +10,17 @@ module use /data/users/lfric/software/modulefiles.rhel7
 
 module load environment/lfric/gcc
 
-# provide explit path set to the arch script for netCDF linking
-export NETCDF_LIB_DIRS=$NETCDF_4_8_1_ROOT/lib:$NETCDF_4_8_1_ROOT/lib64
-export NETCDF_INC_DIRS=$NETCDF_4_8_1_ROOT/include
-
-. arch/arch-GCC_LINUX_APT.path
-
 # provide explicit paths to all XIOS components
 export XIOS_INCDIR=$XIOS_R2252_2_ROOT/include
 export XIOS_LIBDIR=$XIOS_R2252_2_ROOT/lib
 export XIOS_BINDIR=$XIOS_R2252_2_ROOT/bin
+
+# ensure netcdf is on the LD path & flags
+export LD_LIBRARY_PATH=$NETCDF_4_8_1_ROOT/lib:$NETCDF_4_8_1_ROOT/lib64:$LD_LIBRARY_PATH
+export LDFLAGS="-L$XIOS_LIBDIR -lxios -L$NETCDF_4_8_1_ROOT/lib -lnetcdf -L$NETCDF_4_8_1_ROOT/lib64 -lnetcdff -lstdc++"
+
+export FCFLAGS="-g -I$XIOS_INCDIR -I$NETCDF_4_8_1_ROOT/include"
+export FC=mpif90
 
 # use an extend LFRic Python environment
 # that includes netCDF4-python built w.r.t. the LFRIC

--- a/jasminEnv
+++ b/jasminEnv
@@ -5,8 +5,8 @@
 module load jaspy/3.11 # need at least version 3.11 for parallel netcdf support
 
 # provide explit path set to the arch script for netCDF linking
-export NETCDF_LIBDIR=-L$(nc-config --libdir)
-export NETCDF_INCDIR=-I$(nc-config --includedir)
+export NETCDF_LIBDIR=$(nc-config --libdir)
+export NETCDF_INCDIR=$(nc-config --includedir)
 
 # set XIOS build to XIOS2 trunk revision 2628, if not already set
 : ${XIOS_DIR=/home/users/jcole/software/xios_trunk_r2628}
@@ -15,6 +15,13 @@ export NETCDF_INCDIR=-I$(nc-config --includedir)
 export XIOS_INCDIR=$XIOS_DIR/inc
 export XIOS_LIBDIR=$XIOS_DIR/lib
 export XIOS_BINDIR=$XIOS_DIR/bin
+
+# ensure netcdf is on the LD path & flags
+export LD_LIBRARY_PATH=$NETCDF_LIBDIR:$LD_LIBRARY_PATH
+export LDFLAGS="-L$XIOS_LIBDIR -lxios -L$NETCDF_LIBDIR -lnetcdf -lnetcdff -lstdc++"
+
+export FCFLAGS="-g -I$XIOS_INCDIR -I$NETCDF_INCDIR"
+export FC=mpif90
 
 # set env variable for run switching (mpiexec / srun) and iodef patching (transport)
 export PLATFORM=Jasmin

--- a/xios_examples/Makefile
+++ b/xios_examples/Makefile
@@ -7,35 +7,11 @@
 #
 # Environment Variables expected by this MakeFile:
 #
-# NETCDF_LIBDIR: the directories for the netCDF lib files
-#                encoded as a -L string, e.g.
-#                "-L/dir1 -L/dir2"
-# NETCDF_INCDIR: the directories for the netCDF include files
-#                encoded as a -I string, e.g.
-#                "-I/dir3 -I/dir4"
-#     (note, this is for consistency with the XIOS build process
-#      required for the CI build machine.
-#      this is not required for other directories)
-#
-# XIOS_INCDIR: The directory for XIOS include files
-# XIOS_LIBDIR: The directory for XIOS lib files
+# FC: mpif90
+# FCFLAGS: -g & include files for netcdf & xios
+# LD_FLAGS: for xios, netcdf, netcdff, stfc++
+# LD_LIBRARY_PATH: for netCDF & XIOS libs
 # XIOS_BINDIR: The directory for XIOS binary files
-
-FCFLAGS = -g
-
-FC = mpif90       # compiler driver for MPI programs
-
-# compiler flag, includes
-FCFLAGS += -I$(XIOS_INCDIR) $(NETCDF_INCDIR)
-
-# loader flags
-LDFLAGS = \
-	-L$(XIOS_LIBDIR) \
-	$(NETCDF_LIBDIR) \
-	-lxios \
-	-lnetcdf \
-	-lnetcdff \
-	-lstdc++ 
 
 .PHONY: all, clean, run
 

--- a/xios_examples/context_test/Makefile
+++ b/xios_examples/context_test/Makefile
@@ -7,35 +7,11 @@
 #
 # Environment Variables expected by this MakeFile:
 #
-# NETCDF_LIBDIR: the directories for the netCDF lib files
-#                 encoded as a -L string, e.g.
-#                 "-L/dir1 -L/dir2"
-# NETCDF_INCDIR: the directories for the netCDF include files
-#                 encoded as a -I string, e.g.
-#                 "-I/dir3 -I/dir4"
-#     (note, this is for consistency with the XIOS build process
-#      required for the CI build machine.
-#      this is not required for other directories)
-#
-# XIOS_INCDIR: The directory for XIOS include files
-# XIOS_LIBDIR: The directory for XIOS lib files
+# FC: mpif90
+# FCFLAGS: -g & include files for netcdf & xios
+# LD_FLAGS: for xios, netcdf, netcdff, stfc++
+# LD_LIBRARY_PATH: for netCDF & XIOS libs
 # XIOS_BINDIR: The directory for XIOS binary files
-
-FCFLAGS = -g
-
-FC = mpif90 # compiler driver for MPI programs
-
-# compiler flag, includes
-FCFLAGS += -I$(XIOS_INCDIR) $(NETCDF_INCDIR)
-
-# loader flags
-LDFLAGS = \
-        -L$(XIOS_LIBDIR) \
-        $(NETCDF_LIBDIR) \
-        -lxios \
-        -lnetcdf \
-        -lnetcdff \
-        -lstdc++
 
 .PHONY: all, clean, run
 

--- a/xios_examples/packing_scale_offset/Makefile
+++ b/xios_examples/packing_scale_offset/Makefile
@@ -7,35 +7,11 @@
 #
 # Environment Variables expected by this MakeFile:
 #
-# NETCDF_LIBDIR: the directories for the netCDF lib files
-#                encoded as a -L string, e.g.
-#                "-L/dir1 -L/dir2"
-# NETCDF_INCDIR: the directories for the netCDF include files
-#                encoded as a -I string, e.g.
-#                "-I/dir3 -I/dir4"
-#     (note, this is for consistency with the XIOS build process
-#      required for the CI build machine.
-#      this is not required for other directories)
-#
-# XIOS_INCDIR: The directory for XIOS include files
-# XIOS_LIBDIR: The directory for XIOS lib files
+# FC: mpif90
+# FCFLAGS: -g & include files for netcdf & xios
+# LD_FLAGS: for xios, netcdf, netcdff, stfc++
+# LD_LIBRARY_PATH: for netCDF & XIOS libs
 # XIOS_BINDIR: The directory for XIOS binary files
-
-FCFLAGS = -g
-
-FC = mpif90       # compiler driver for MPI programs
-
-# compiler flag, includes
-FCFLAGS += -I$(XIOS_INCDIR) $(NETCDF_INCDIR)
-
-# loader flags
-LDFLAGS = \
-	-L$(XIOS_LIBDIR) \
-	$(NETCDF_LIBDIR) \
-	-lxios \
-	-lnetcdf \
-	-lnetcdff \
-	-lstdc++ 
 
 .PHONY: all, clean, run
 

--- a/xios_examples/split_file_test/Makefile
+++ b/xios_examples/split_file_test/Makefile
@@ -7,35 +7,12 @@
 #
 # Environment Variables expected by this MakeFile:
 #
-# NETCDF_LIBDIR: the directories for the netCDF lib files
-#                encoded as a -L string, e.g.
-#                "-L/dir1 -L/dir2"
-# NETCDF_INCDIR: the directories for the netCDF include files
-#                encoded as a -I string, e.g.
-#                "-I/dir3 -I/dir4"
-#     (note, this is for consistency with the XIOS build process
-#      required for the CI build machine.
-#      this is not required for other directories)
-#
-# XIOS_INCDIR: The directory for XIOS include files
-# XIOS_LIBDIR: The directory for XIOS lib files
+# FC: mpif90
+# FCFLAGS: -g & include files for netcdf & xios
+# LD_FLAGS: for xios, netcdf, netcdff, stfc++
+# LD_LIBRARY_PATH: for netCDF & XIOS libs
 # XIOS_BINDIR: The directory for XIOS binary files
 
-FCFLAGS = -g
-
-FC = mpif90       # compiler driver for MPI programs
-
-# compiler flag, includes
-FCFLAGS += -I$(XIOS_INCDIR) $(NETCDF_INCDIR)
-
-# loader flags
-LDFLAGS = \
-	-L$(XIOS_LIBDIR) \
-	$(NETCDF_LIBDIR) \
-	-lxios \
-	-lnetcdf \
-	-lnetcdff \
-	-lstdc++ 
 
 .PHONY: all, clean, run
 

--- a/xios_examples/write_domain_parallel/Makefile
+++ b/xios_examples/write_domain_parallel/Makefile
@@ -7,35 +7,11 @@
 #
 # Environment Variables expected by this MakeFile:
 #
-# NETCDF_LIBDIR: the directories for the netCDF lib files
-#                 encoded as a -L string, e.g.
-#                 "-L/dir1 -L/dir2"
-# NETCDF_INCDIR: the directories for the netCDF include files
-#                 encoded as a -I string, e.g.
-#                 "-I/dir3 -I/dir4"
-#     (note, this is for consistency with the XIOS build process
-#      required for the CI build machine.
-#      this is not required for other directories)
-#
-# XIOS_INCDIR: The directory for XIOS include files
-# XIOS_LIBDIR: The directory for XIOS lib files
+# FC: mpif90
+# FCFLAGS: -g & include files for netcdf & xios
+# LD_FLAGS: for xios, netcdf, netcdff, stfc++
+# LD_LIBRARY_PATH: for netCDF & XIOS libs
 # XIOS_BINDIR: The directory for XIOS binary files
-
-FCFLAGS = -g
-
-FC = mpif90       # compiler driver for MPI programs
-
-# compiler flag, includes
-FCFLAGS += -I$(XIOS_INCDIR) $(NETCDF_INCDIR)
-
-# loader flags
-LDFLAGS = \
-	-L$(XIOS_LIBDIR) \
-	$(NETCDF_LIBDIR) \
-	-lxios \
-	-lnetcdf \
-	-lnetcdff \
-	-lstdc++ 
 
 all: write_parallel
 


### PR DESCRIPTION
this PR updates the Environment management processes for the platforms using this code.

The responsibility for setting environment variables is fully put onto the environment setup, with no changes in any `Makefile` instances. This simplifies the `Makefile`s and puts all of the platform specific code in one place per platform.

The requirements are for
`LD_LIBRARY_PATH`, `LDFLAGS`, `FCFLAGS` & `FC`
to be provided to enable all builds on the platform

this change makes it slightly clearer to add a new platform, as evidenced by the azSpice addition

this change should also simplify addressing #34 & #37

it does not address #35, which is addressed within #36 (as yet unmerged)