### PR TITLE
pin version of ubuntu in xios build

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -23,7 +23,11 @@ jobs:
             sudo apt -yq install $(<dependencies)
       - name: clone and build XIOS
         run: |
-          svn co http://forge.ipsl.fr/ioserver/svn/${{ matrix.version }} XIOS
+          if [ ${{ matrix.version }} == 'XIOS3/trunk' ]; then
+            svn co http://forge.ipsl.fr/ioserver/svn/${{ matrix.version }}@2686 XIOS
+          else
+            svn co http://forge.ipsl.fr/ioserver/svn/${{ matrix.version }} XIOS
+          fi
           cp arch/* XIOS/arch/
           cd XIOS
           if [ ${{ matrix.version }} == 'XIOS3/trunk' ]; then

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_test:
     name: build test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         version: [XIOS/trunk@2252, XIOS2/trunk, XIOS3/trunk]

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -23,15 +23,10 @@ jobs:
             sudo apt -yq install $(<dependencies)
       - name: clone and build XIOS
         run: |
-          if [ ${{ matrix.version }} == 'XIOS3/trunk' ]; then
-            svn co http://forge.ipsl.fr/ioserver/svn/${{ matrix.version }}@2686 XIOS
-          else
-            svn co http://forge.ipsl.fr/ioserver/svn/${{ matrix.version }} XIOS
-          fi
+          svn co http://forge.ipsl.fr/ioserver/svn/${{ matrix.version }} XIOS
           cp arch/* XIOS/arch/
           cd XIOS
           if [ ${{ matrix.version }} == 'XIOS3/trunk' ]; then
-            patch -p0 < ../patches/xios3/revert_svn2517_transport.patch
             sed -i 's/<variable_group id="parameters" >/<variable_group id="parameters" > <variable id="transport_protocol" type="string" >p2p<\/variable>/g' generic_testcase/iodef.xml
             cat generic_testcase/iodef.xml
           fi


### PR DESCRIPTION
does not address #39 
this is a short term work around by retaining an old version of ubuntu until we figure out the new build instructions for ubuntu 24.04
this also pins the XIOS3 version, as the patch required for github testing is failing to patch, this also needs investigating and fixing