### PR TITLE
Add new CITATIONS.cff file to list code contributors

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,22 +3,16 @@ message: "If you use this software, please cite it as below."
 authors:
 - family-names: "Adams"
   given-names: "Samantha"
-authors:
 - family-names: "Cole"
   given-names: "Jeff"
-authors:
 - family-names: "Hedley"
   given-names: "Mark"
-authors:
 - family-names: "Kavčič"
   given-names: "Iva"
-authors:
 - family-names: "Mannall"
   given-names: "Nathan"
-authors:
 - family-names: "Olivier"
   given-names: "Ricky"
-authors:
 - family-names: "Shepherd"
   given-names: "Harry"
 title: "Demonstration code repository for XIOS (XML I/O server) usage."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Adams"
+  given-names: "Samantha"
+authors:
+- family-names: "Cole"
+  given-names: "Jeff"
+authors:
+- family-names: "Hedley"
+  given-names: "Mark"
+authors:
+- family-names: "Kavčič"
+  given-names: "Iva"
+authors:
+- family-names: "Mannall"
+  given-names: "Nathan"
+authors:
+- family-names: "Olivier"
+  given-names: "Ricky"
+authors:
+- family-names: "Shepherd"
+  given-names: "Harry"
+title: "Demonstration code repository for XIOS (XML I/O server) usage."
+version:
+doi:
+date-released:
+url: "https://github.com/MetOffice/tcd-XIOS-demonstration"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,20 +17,10 @@ the behaviour that is being demonstrated by the contribution.
 
 ## Code Contributors
 
-The following people have contributed to this code under the terms of
-the Contributor Licence Agreement and Certificate of Origin detailed
-below:
+The current list of code contributors is maintained in the CITATION.cff.
+All contributors are identifiable with email addresses in the version control
+logs or otherwise.
 
-<!-- start-shortlog -->
- - Iva Kavčič (Met Office, UK)
- - Mark Hedley (Met Office, UK)
- - Harry Shepherd (Met Office, UK)
- - Jeff Cole (NCAS, University of Reading, UK)
- - Ricky Olivier (University of Exeter, UK)
-<!-- end-shortlog -->
-
-(All contributors are identifiable with email addresses in the version control
-logs or otherwise.)
 
 ## Contributor Licence Agreement and Certificate of Origin
 


### PR DESCRIPTION
Created CITATIONS.cff file and added names of all currrent contributors. Removed names from CONTRIBUTORS.md. 

It is possible to add other things to the citations file such as author ORCIDs, release information and a DOI if we wanted to make a formal release of the repo and generate a DOI at some point. I have left placeholders in the file for release info and DOI.

More information available here: https://citation-file-format.github.io/