### PR TITLE
added CFFLAGS and LDFLAGS to quantize_github call in makefile.

### DIFF
--- a/netcdf_examples/quantize_test/Makefile
+++ b/netcdf_examples/quantize_test/Makefile
@@ -4,13 +4,12 @@ CC = cc
 
 all: quantize
 
+# added CFFLAGS, LDFLAGS and package lm to both
 quantize: quantize.c quantize.h quantize_params.c
-	$(CC) quantize.c -lnetcdf -o quantize.exe
+	$(CC) $(CFLAGS) quantize.c $(LDFLAGS) -lnetcdf -lm -o quantize.exe
 
 quantize_github: quantize.c quantize.h quantize_params.c
-	$(CC) quantize.c -lnetcdf -lm -o quantize.exe
-
-
+	$(CC) $(CFLAGS) quantize.c $(LDFLAGS) -lnetcdf -lm -o quantize.exe
 
 clean:
 	rm -rf *exe core *nc


### PR DESCRIPTION
Those flags, as well as the linker param -lm, were added to the quantize and quantize_github directives of the quantize makefile. 