### PR TITLE
Read axis values demonstration

### DIFF
--- a/xios_examples/read_axis_values/Makefile
+++ b/xios_examples/read_axis_values/Makefile
@@ -1,0 +1,34 @@
+# Make file for the resample demonstartion XIOS programme
+# Targets provided our detailed below...
+#
+# all: (default) Build the resample programme
+# clean: Delete all final products and working files
+# run: run the programme
+#
+# Environment Variables expected by this MakeFile:
+#
+# FC: mpif90
+# FCFLAGS: -g & include files for netcdf & xios
+# LD_FLAGS: for xios, netcdf, netcdff, stfc++
+# LD_LIBRARY_PATH: for netCDF & XIOS libs
+# XIOS_BINDIR: The directory for XIOS binary files
+
+.PHONY: all, clean, run
+
+all: client
+
+# fortran compilation
+%.o: %.F90
+	$(FC) $(FCFLAGS) -c $<
+
+# fortran linking
+client: client.o
+	$(FC) -o client.exe client.o $(LDFLAGS) \
+		&& ln -fs $(XIOS_BINDIR)/xios_server.exe .
+
+run:
+	mpiexec -n 1 ./client.exe : -n 1 ./xios_server.exe
+
+# cleanup
+clean:
+	rm -f *.exe *.o *.mod *.MOD *.out *.err

--- a/xios_examples/read_axis_values/README.md
+++ b/xios_examples/read_axis_values/README.md
@@ -1,0 +1,17 @@
+Read axis values
+------
+
+This example demonstrates a bug when reading axis values from an input file.
+
+The configuration file `main.xml` defines two axis `x` and `y`, but does not
+set their dimensions. Instead the client program (`client.F90`) sets this using
+the fortran interface (lines 115 and 116). Both axis are set to have values:
+`[2, 4, 6, 8, 10, 12, 14, 16, 18, 20]`.
+
+However, the configuration includes an input file `input_data.nc`. When closing
+the context definition, XIOS reads the axis values from this file which should
+be: `[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]`. However, the output file `output_data.nc`
+ends up containing values `[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]`.
+
+This bug only occurs when `par_access="independent"` is set on the input file.
+If `par_access="collective"` is used instead, the test will pass.

--- a/xios_examples/read_axis_values/__init__.py
+++ b/xios_examples/read_axis_values/__init__.py
@@ -1,0 +1,3 @@
+"""
+Enable this folder to be a module path, for imports and test discovery.
+"""

--- a/xios_examples/read_axis_values/client.F90
+++ b/xios_examples/read_axis_values/client.F90
@@ -1,0 +1,155 @@
+!-----------------------------------------------------------------------------
+! (C) Crown copyright 2025 Met Office. All rights reserved.
+! The file LICENCE, distributed with this code, contains details of the terms
+! under which the code may be used.
+!-----------------------------------------------------------------------------
+!> Saves to disk a pressure field read from an input file.
+!> This tests that XIOS correctly reads the axis values from from the input
+!> file.
+!>
+!> The client sets the x and y axis values to [2, 4, 6, 8, ... ], however the
+!> input file contains x and y axis values of [1, 2, 3, 4, ... ]. XIOS should
+!> read these from the input file and correctly overwrite the existing values.
+!>
+!> While XIOS will check that the dimensions of the axis defined by the user
+!> match those defined in the input file, the values in the input file take
+!> precedence over any user defined values.
+
+module partition_mod
+  use mpi
+  implicit none
+
+  type :: partition_info 
+    integer :: ni_global, nj_global
+    integer :: ni_local, nj_local
+    integer :: ibegin_global, jbegin_global
+  end type
+
+  contains 
+
+  subroutine create_partition(ni_global, nj_global, comm, info)
+    type(partition_info), intent(out) :: info 
+    integer, intent(in) :: ni_global, nj_global
+    integer, intent(in) :: comm
+
+    integer :: n_ranks
+    integer :: rank
+    integer :: ierr
+
+    call MPI_Comm_rank(comm, rank, ierr)
+    call MPI_Comm_size(comm, n_ranks, ierr)
+
+    info%ni_global = ni_global
+    info%nj_global = nj_global
+    info%ni_local = ni_global / n_ranks
+    info%ibegin_global = rank * info%ni_local
+    info%nj_local = nj_global
+    info%ibegin_global = 0
+
+  end subroutine
+
+end module
+
+
+program client
+  use xios
+  use mpi
+  use ifile_attr
+  use partition_mod
+  implicit none
+
+  integer :: ierr = 0
+  type(partition_info) :: pinfo 
+
+  call MPI_INIT(ierr)
+
+  call initialise(pinfo)
+  call simulate(pinfo)
+  call finalise()
+
+  call MPI_Finalize(ierr)
+
+contains
+
+  subroutine initialise(pinfo)
+
+    integer :: comm = -1
+    integer :: i, j
+    double precision, dimension (:), allocatable :: x_values
+    double precision, dimension (:), allocatable :: y_values
+    type(xios_date) :: origin
+    type(xios_date) :: start
+    type(xios_duration) :: tstep
+    type(xios_file) :: file_hdl
+    type(xios_axis) :: axis_hdl
+    type(partition_info), intent(out) :: pinfo
+
+    ! Datetime setup
+    origin = xios_date(2022, 12, 12, 12, 0, 0)
+    start = xios_date(2022, 12, 12, 12, 0, 0)
+    tstep = xios_hour
+
+    ! Initialise MPI and XIOS
+    call xios_initialize('client', return_comm=comm)
+
+    call xios_context_initialize('main', comm)
+    call xios_set_time_origin(origin)
+    call xios_set_start_date(start)
+    call xios_set_timestep(tstep)
+
+    call create_partition(10, 10, comm, pinfo) ! distribute levels in the field across clients and save distribution info in pinfo
+
+    ! Set x axis values to [2, 4, 6, 8, ... ]
+    allocate ( x_values(pinfo%ni_local) )
+    do i=1, pinfo%ni_local
+      x_values(i) = 2 * (i + pinfo%ibegin_global)
+    enddo
+
+    ! Set y axis values to [2, 4, 6, 8, ... ]
+    allocate ( y_values(pinfo%nj_local) )
+    do j=1, pinfo%nj_local
+      y_values(j) = 2 * (j + pinfo%jbegin_global)
+    enddo
+
+    ! Set the axis attributes
+    call xios_set_axis_attr("x", n_glo=pinfo%ni_global, begin=pinfo%ibegin_global, n=pinfo%ni_local, value=x_values)
+    call xios_set_axis_attr("y", n_glo=pinfo%nj_global, begin=pinfo%jbegin_global, n=pinfo%nj_local, value=y_values)
+
+    call xios_close_context_definition()
+    
+  end subroutine initialise
+
+
+  subroutine finalise()
+
+    ! Finalise XIOS and MPI
+    call xios_context_finalize()
+
+    call xios_finalize()
+
+  end subroutine finalise
+
+
+  subroutine simulate(pinfo)
+
+    type(partition_info), intent(in) :: pinfo 
+    integer :: ts
+    integer :: ilevel, jlevel
+    double precision, dimension (:, :), allocatable :: inpdata
+
+    allocate ( inpdata(pinfo%ni_local, pinfo%nj_local) )
+
+    ! Read the pressure data from the output file.
+    call xios_recv_field('pressure_in', inpdata)
+
+    ! Send the pressure data to the output file.
+    do ts=1, 1
+      call xios_update_calendar(ts)
+      call xios_send_field('pressure', inpdata)
+    enddo
+
+    deallocate ( inpdata )
+
+  end subroutine simulate
+
+end program client

--- a/xios_examples/read_axis_values/input_data.cdl
+++ b/xios_examples/read_axis_values/input_data.cdl
@@ -1,0 +1,71 @@
+netcdf input_data {
+dimensions:
+	axis_nbounds = 2 ;
+	x = 10 ;
+	y = 10 ;
+	time_counter = UNLIMITED ; // (1 currently)
+variables:
+  float x(x) ;
+		x:name = "x" ;
+  float y(y) ;
+		y:name = "y" ;
+	double time_instant(time_counter) ;
+		time_instant:standard_name = "time" ;
+		time_instant:long_name = "Time axis" ;
+		time_instant:calendar = "gregorian" ;
+		time_instant:units = "seconds since 2022-12-12 12:00:00" ;
+		time_instant:time_origin = "2022-12-12 12:00:00" ;
+		time_instant:bounds = "time_instant_bounds" ;
+	double time_instant_bounds(time_counter, axis_nbounds) ;
+	double time_counter(time_counter) ;
+		time_counter:axis = "T" ;
+		time_counter:standard_name = "time" ;
+		time_counter:long_name = "Time axis" ;
+		time_counter:calendar = "gregorian" ;
+		time_counter:units = "seconds since 2022-12-12 12:00:00" ;
+		time_counter:time_origin = "2022-12-12 12:00:00" ;
+		time_counter:bounds = "time_counter_bounds" ;
+	double time_counter_bounds(time_counter, axis_nbounds) ;
+	float pressure(time_counter, y, x) ;
+		pressure:standard_name = "air_pressure" ;
+		pressure:long_name = "Air Pressure" ;
+		pressure:units = "Pa" ;
+		pressure:online_operation = "instant" ;
+		pressure:interval_operation = "1 h" ;
+		pressure:interval_write = "1 h" ;
+		pressure:cell_methods = "time: point" ;
+		pressure:coordinates = "time_instant" ;
+
+// global attributes:
+		:name = "output_data" ;
+		:description = "Created by xios" ;
+		:title = "Created by xios" ;
+		:Conventions = "CF-1.6" ;
+		:timeStamp = "2025-Oct-15 14:52:57 GMT" ;
+		:uuid = "ed357d3a-500f-42a9-bbfc-021070a7790b" ;
+data:
+
+ time_instant = 3600 ;
+
+ time_instant_bounds = 3600, 3600 ;
+
+ time_counter = 3600 ;
+
+ time_counter_bounds = 3600, 3600 ;
+
+ x = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ;
+
+ y = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ;
+
+ pressure =
+  111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+  121, 122, 123, 124, 125, 126, 127, 128, 129, 130,
+  131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
+  141, 142, 143, 144, 145, 146, 147, 148, 149, 150,
+  151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
+  161, 162, 163, 164, 165, 166, 167, 168, 169, 170,
+  171, 172, 173, 174, 175, 176, 177, 178, 179, 180,
+  181, 182, 183, 184, 185, 186, 187, 188, 189, 190,
+  191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
+  201, 202, 203, 204, 205, 206, 207, 208, 209, 210 ;
+}

--- a/xios_examples/read_axis_values/iodef.xml
+++ b/xios_examples/read_axis_values/iodef.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<simulation>
+
+<context id="main" src="main.xml"/>
+<context id="xios" src="xios.xml"/>
+
+</simulation>

--- a/xios_examples/read_axis_values/main.xml
+++ b/xios_examples/read_axis_values/main.xml
@@ -1,0 +1,36 @@
+<!--
+Input file to test reading axis values from an input file in XIOS.
+
+The input file is read using the independent read mode.
+-->
+
+<context>
+
+  <calendar type="Gregorian"/>
+
+  <axis_definition>
+    <axis id="x" comment="Dimensions set by the client"/>
+    <axis id="y" comment="Dimensions set by the client"/>
+  </axis_definition>
+
+  <grid_definition>
+    <grid id="model">
+      <axis axis_ref="x"/>
+      <axis axis_ref="y"/>
+    </grid>
+  </grid_definition>
+
+  <field_definition freq_op="1ts" enabled=".TRUE." operation="instant">
+    <field id="pressure" long_name="Air Pressure" standard_name="air_pressure" unit="Pa" grid_ref="model"/>
+  </field_definition>
+
+  <file_definition type="one_file">
+    <file id="input_data" mode="read" output_freq="1ts" par_access="independent">
+      <field id="pressure_in" name="pressure" freq_op="1ts" operation="instant" grid_ref="model"/>
+    </file>
+    <file id="output_data" output_freq="1ts">
+      <field field_ref="pressure"/>
+    </file>
+  </file_definition>
+
+</context>

--- a/xios_examples/read_axis_values/test_read_axis_values.py
+++ b/xios_examples/read_axis_values/test_read_axis_values.py
@@ -1,0 +1,42 @@
+from typing import List
+from netCDF4 import Dataset
+import numpy as np
+import numpy.testing as npt
+import os
+
+import xios_examples.shared_testing as xshared
+
+this_path = os.path.realpath(__file__)
+this_dir = os.path.dirname(this_path)
+
+class TestReadAxisValues(xshared._TestCase):
+    test_dir = this_dir
+    transient_inputs = ['input_data.nc']
+    transient_outputs = ["output_data.nc"]
+    executable = "./client.exe"
+    axis_size = 10
+
+    def test_axis_values(self):
+        self.make_netcdf("input_data.cdl", self.transient_inputs[0])
+        self.run_mpi_xios()
+        self.check_axis("x")
+        self.check_axis("y")       
+
+    def check_axis(self, axis_name):
+        outputfile = '{}/{}'.format(self.test_dir, self.transient_outputs[0])
+        rootgrp = Dataset(outputfile, "r")
+        axis = rootgrp.variables[axis_name]
+        axis_values = axis[:]
+
+        # Calculate expected value and diff
+        expected = np.arange(1, self.axis_size + 1, dtype=np.float32)
+        diff = axis_values - expected
+
+        # prepare message for failure
+        msg = (
+            f"{outputfile}[{axis.name}]: the expected result\n {expected}\n"
+            f" differs from the actual result\n {axis_values} \n"
+            f" with diff \n {diff}\n"
+        )
+
+        npt.assert_allclose(axis_values, expected, rtol=self.rtol, err_msg=msg)

--- a/xios_examples/read_axis_values/xios.xml
+++ b/xios_examples/read_axis_values/xios.xml
@@ -1,0 +1,22 @@
+<context>
+  <variable_definition>
+    <variable_group id="buffer">
+      <variable id="optimal_buffer_size" type="string">
+	performance
+      </variable>
+      <variable id="buffer_size_factor" type="double">
+	1.0
+      </variable>
+    </variable_group>
+    
+    <variable_group id="parameters" >
+       <variable id="using_server" type="bool">true</variable>
+       <variable id="info_level" type="int">
+	100
+      </variable>
+      <variable id="print_file" type="bool">
+	true
+      </variable>
+    </variable_group>
+  </variable_definition>
+</context>


### PR DESCRIPTION
This PR adds a new XIOS example to demonstrate a bug caused by axis values being overwritten with uninitialised data when reading a file using independent reads.

The demonstration currently fails when running in the CI.